### PR TITLE
Supporting fast-proxy-lite as default proxy library

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,6 @@ You can support the maintenance of this project:
 
 ## Breaking Changes
 ### v3.x
-- The `fast-proxy-lite` module is used by default to support `http` proxy type 🔥
+- The `fast-proxy-lite` module is used by default to support `http` proxy type 🔥. This means, no `undici` or `http2` are supported by default.
 - The old `fast-proxy` module is available under the `http-legacy` proxy type, but the module is not installed by default.
 - Proxy configuration is now generalized under the `proxyConfig` property.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A super fast, framework agnostic Node.js API Gateway for the masses ❤️
 ## Medium articles:
 - https://itnext.io/a-js-api-gateway-for-the-masses-a12fdb9e961c
 
-
 ## Install
 ```js
 npm i fast-gateway
@@ -46,10 +45,10 @@ npm i http-lambda-proxy
 const gateway = require('fast-gateway')
 const server = gateway({
   routes: [{
-    proxyType: 'lambda',
     prefix: '/service',
     target: 'my-lambda-serverless-api',
-    lambdaProxy: {
+    proxyType: 'lambda',
+    proxyConfig: {
       region: 'eu-central-1'
     }
   }]
@@ -104,27 +103,27 @@ module.exports.handler = serverless(service)
   timeout: 0,
   // Optional "target" value that overrides the routes "target" config value. Feature intended for testing purposes.
   targetOverride: "https://yourdev.api-gateway.com",
+  // Optional "Proxy Factory" implementation, allows the integration of custom proxying strategies.
+  // Default value: require('fast-proxy-lite/lib/proxy-factory')
+  proxyFactory: ({ proxyType, opts, route }) => {...}
 
   // HTTP proxy
   routes: [{
-    // Optional proxy type definition. Supported values: http, lambda
+    // Optional proxy type definition. Supported values: http, http-legacy, lambda
+    // Modules:
+    // - http: fast-proxy-lite
+    // - http-legacy: fast-proxy
+    // - lambda: http-lambda-proxy
     // Default value: http
     proxyType: 'http'
-    // Optional `fast-proxy` library configuration (https://www.npmjs.com/package/fast-proxy#options)
-    // base parameter defined as the route target. Default value: {}
-    // This settings apply only when proxyType = 'http'
-    fastProxy: {},
-    // Optional `http-lambda-proxy` library configuration (https://www.npmjs.com/package/http-lambda-proxy#options)
-    // The 'target' parameter is extracted from route.target, default region = 'eu-central-1'
-    // This settings apply only when proxyType = 'lambda'
-    lambdaProxy: {
-      region: 'eu-central-1'
-    },
+    // Optional proxy library configuration: 
+    // - fast-proxy-lite: https://www.npmjs.com/package/fast-proxy-lite#options
+    // - fast-proxy: https://www.npmjs.com/package/fast-proxy#options
+    // - http-lambda-proxy: https://www.npmjs.com/package/http-lambda-proxy#options
+    // Default value: {}
+    proxyConfig: {},
     // Optional proxy handler function. Default value: (req, res, url, proxy, proxyOpts) => proxy(req, res, url, proxyOpts)
     proxyHandler: () => {},
-    // Optional flag to indicate if target uses the HTTP2 protocol. Default value: false
-    // This setting apply only when proxyType = 'http'
-    http2: false,
     // Optional path matching regex. Default value: '/*'
     // In order to disable the 'pathRegex' at all, you can use an empty string: ''
     pathRegex: '/*',
@@ -167,7 +166,7 @@ module.exports.handler = serverless(service)
         // ...
       }
 
-      // if proxyType= 'http', other options allowed https://www.npmjs.com/package/fast-proxy#opts
+      // if proxyType= 'http', other options allowed https://www.npmjs.com/package/fast-proxy-lite#opts
     }
   }]
 }
@@ -384,7 +383,7 @@ routes: [{
 
 ## Related projects
 - middleware-if-unless (https://www.npmjs.com/package/middleware-if-unless)
-- fast-proxy (https://www.npmjs.com/package/fast-proxy)
+- fast-proxy-lite (https://www.npmjs.com/package/fast-proxy-lite)
 - http-lambda-proxy (https://www.npmjs.com/package/http-lambda-proxy)
 - restana (https://www.npmjs.com/package/restana)
 
@@ -403,3 +402,10 @@ Benchmark scripts can be found in benchmark folder.
 You can support the maintenance of this project: 
 - PayPal: https://www.paypal.me/kyberneees
 - [TRON](https://www.binance.com/en/buy-TRON) Wallet: `TJ5Bbf9v4kpptnRsePXYDvnYcYrS5Tyxus`
+
+
+## Breaking Changes
+### v3.x
+- The `fast-proxy-lite` module is used by default to support `http` proxy type 🔥
+- The old `fast-proxy` module is available under the `http-legacy` proxy type, but the module is not installed by default.
+- Proxy configuration is now generalized under the `proxyConfig` property.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,21 +5,21 @@ declare namespace fastgateway {
 
   type Method = 'GET' | 'DELETE' | 'PATCH' | 'POST' | 'PUT' | 'HEAD' | 'OPTIONS' | 'TRACE';
 
-  interface LambdaProxy {
-    region?: string;
-    target?: string;
-  }
-
   interface Docs {
     name: string;
     endpoint: string;
     type: string;
   }
 
+  interface ProxyFactoryOpts {
+    proxyType: string;
+    opts: {};
+    route: Route;
+  }
+
   interface Route {
     proxyType?: Type;
-    fastProxy?: {};
-    lambdaProxy?: LambdaProxy;
+    proxyConfig?: {};
     proxyHandler?: Function;
     http2?: boolean;
     pathRegex?: string;
@@ -48,6 +48,7 @@ declare namespace fastgateway {
   
   interface Options<P extends restana.Protocol> {
     server?: Object | restana.Service<P> | Express.Application;
+    proxyFactory?: (opts: ProxyFactoryOpts) => Function;
     restana?: {};
     middlewares?: Function[];
     pathRegex?: string;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable no-useless-call */
 
-const proxyFactory = require('./lib/proxy-factory')
+const defaultProxyFactory = require('./lib/proxy-factory')
 const restana = require('restana')
 const defaultProxyHandler = (req, res, url, proxy, proxyOpts) => proxy(req, res, url, proxyOpts)
 const DEFAULT_METHODS = require('restana/libs/methods').filter(method => method !== 'all')
@@ -10,6 +10,8 @@ const send = require('@polka/send-type')
 const PROXY_TYPES = ['http', 'lambda']
 
 const gateway = (opts) => {
+  const proxyFactory = opts.proxyFactory || defaultProxyFactory
+
   opts = Object.assign({
     middlewares: [],
     pathRegex: '/*'

--- a/lib/proxy-factory.js
+++ b/lib/proxy-factory.js
@@ -1,21 +1,28 @@
 'use strict'
 
-const fastProxy = require('fast-proxy')
+const fastProxy = require('fast-proxy-lite')
 
 module.exports = ({ proxyType, opts, route }) => {
   let proxy
+
   if (proxyType === 'http') {
     proxy = fastProxy({
       base: opts.targetOverride || route.target,
-      http2: !!route.http2,
-      ...(route.fastProxy)
+      ...(route.proxyConfig)
     }).proxy
   } else if (proxyType === 'lambda') {
     proxy = require('http-lambda-proxy')({
       target: opts.targetOverride || route.target,
       region: 'eu-central-1',
-      ...(route.lambdaProxy || {})
+      ...(route.proxyConfig)
     })
+  } else if (proxyType === 'http-legacy') {
+    proxy = require('fast-proxy')({
+      base: opts.targetOverride || route.target,
+      ...(route.proxyConfig)
+    }).proxy
+  } else {
+    throw new Error(`Unsupported proxy type: ${proxyType}!`)
   }
 
   return proxy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-gateway",
-  "version": "2.9.4",
+  "version": "3.0.0",
   "description": "A Node.js API Gateway for the masses!",
   "main": "index.js",
   "types": "index.d.ts",
@@ -28,9 +28,9 @@
   "homepage": "https://github.com/jkyberneees/fast-gateway#readme",
   "dependencies": {
     "@polka/send-type": "^0.5.2",
-    "fast-proxy": "^2.1.0",
+    "fast-proxy-lite": "^1.0.1",
     "http-cache-middleware": "^1.3.8",
-    "restana": "^4.9.1",
+    "restana": "^4.9.2",
     "stream-to-array": "^2.3.0"
   },
   "files": [
@@ -42,12 +42,12 @@
   ],
   "devDependencies": {
     "@types/express": "^4.17.11",
-    "aws-sdk": "^2.1018.0",
+    "aws-sdk": "^2.1023.0",
     "chai": "^4.3.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-jwt": "^6.1.0",
-    "express-rate-limit": "^5.5.0",
+    "express-rate-limit": "^5.5.1",
     "fg-multiple-hooks": "^1.3.0",
     "helmet": "^4.6.0",
     "http-lambda-proxy": "^1.1.4",


### PR DESCRIPTION
Changes:
- The `fast-proxy-lite` module is used by default to support `http` proxy type 🔥
- The old `fast-proxy` module is available under the `http-legacy` proxy type, but the module is not installed by default.
- Proxy configuration is now generalized under the `proxyConfig` property.