### PR TITLE
fix: adds missing type for urlRewrite hook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ declare namespace fastgateway {
     target: string;
     methods?: Method[];
     middlewares?: Function[];
+    urlRewrite?: Function;
     hooks?: Hooks;
   }
 


### PR DESCRIPTION
This change adds type for `urlRewrite: Function` in `Route` interface. `urlRewrite` is present since v2.8.0 but its not present in types definition. Hence, this should fix it.