### PR TITLE
Introducing WebSocket Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ typings/
 
 # next.js build output
 .next
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Example output:
 > NOTE: Please see `docs` configuration entry explained above.
 
 ### WebSockets support
-WebSockets proxying is supported since `v3.1.0`:
+WebSockets proxying is supported since `v3.1.0`. Main considerations:
 - WebSockets middlewares are not supported.
 - WebSocketRoute configuration definition:
   ```ts

--- a/README.md
+++ b/README.md
@@ -196,6 +196,41 @@ Example output:
 ```
 > NOTE: Please see `docs` configuration entry explained above.
 
+### WebSockets support
+WebSockets proxying is supported since `v3.1.0`:
+- WebSockets middlewares are not supported.
+- WebSocketRoute configuration definition:
+  ```ts
+  interface WebSocketRoute {
+    proxyType: 'websocket';
+    // https://github.com/faye/faye-websocket-node#initialization-options
+    proxyConfig?: {}; 
+    prefix: string;
+    target: string;
+    // https://github.com/faye/faye-websocket-node#subprotocol-negotiation
+    subProtocols?: []; 
+    hooks?: WebSocketHooks;
+  }
+
+  interface WebSocketHooks {
+    onOpen?: (ws: any, searchParams: URLSearchParams) => Promise<void>;
+  }
+  ```
+- The `/` route prefix is considered the default route. 
+
+#### Configuration example:
+```js
+gateway({
+  routes: [{
+    // ... other HTTP or WebSocket routes
+  }, {
+    proxyType: 'websocket',
+    prefix: '/echo',
+    target: 'ws://ws.ifelse.io'
+  }]
+}).start(PORT)
+```
+
 ## Timeouts and Unavailability 
 We can restrict requests timeouts globally or at service level using the `timeout` configuration.  
 

--- a/benchmark/websocket/artillery-perf1.yml
+++ b/benchmark/websocket/artillery-perf1.yml
@@ -1,0 +1,11 @@
+config:
+  target: "ws://localhost:8080/echo"
+  phases:
+    - duration: 15  # test for 20 seconds
+      arrivalRate: 20 # every second, add 10 users
+      rampTo: 500 # ramp it up to 100 users over the 20s period
+      name: "Ramping up the load"
+scenarios:
+  - engine: "ws"
+    flow:
+      - send: 'echo me'

--- a/benchmark/websocket/artillery-perf1.yml
+++ b/benchmark/websocket/artillery-perf1.yml
@@ -1,9 +1,9 @@
 config:
   target: "ws://localhost:8080/echo"
   phases:
-    - duration: 15  # test for 20 seconds
-      arrivalRate: 20 # every second, add 10 users
-      rampTo: 500 # ramp it up to 100 users over the 20s period
+    - duration: 15
+      arrivalRate: 20
+      rampTo: 500
       name: "Ramping up the load"
 scenarios:
   - engine: "ws"

--- a/benchmark/websocket/echo.js
+++ b/benchmark/websocket/echo.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const gateway = require('../../index')
+const WebSocket = require('faye-websocket')
+const http = require('http')
+
+gateway({
+  routes: [{
+    proxyType: 'websocket',
+    prefix: '/echo',
+    target: 'ws://127.0.0.1:3000'
+  }]
+}).start(8080)
+
+
+const service = http.createServer()
+service.on('upgrade', (request, socket, body) => {
+  if (WebSocket.isWebSocket(request)) {
+    const ws = new WebSocket(request, socket, body)
+    
+    ws.on('message', (event) => {
+      ws.send(event.data)
+    })
+  }
+})
+service.listen(3000)

--- a/benchmark/websocket/echo.js
+++ b/benchmark/websocket/echo.js
@@ -12,12 +12,11 @@ gateway({
   }]
 }).start(8080)
 
-
 const service = http.createServer()
 service.on('upgrade', (request, socket, body) => {
   if (WebSocket.isWebSocket(request)) {
     const ws = new WebSocket(request, socket, body)
-    
+
     ws.on('message', (event) => {
       ws.send(event.data)
     })

--- a/demos/ws-proxy.js
+++ b/demos/ws-proxy.js
@@ -1,0 +1,14 @@
+const http = require('http')
+const WebSocket = require('faye-websocket')
+
+const server = http.createServer()
+
+server.on('upgrade', (request, socket, body) => {
+  const client = new WebSocket(request, socket, body)
+  const target = new WebSocket.Client('ws://ws.ifelse.io')
+
+  client.pipe(target)
+  target.pipe(client)
+})
+
+server.listen(3000)

--- a/demos/ws-proxy.js
+++ b/demos/ws-proxy.js
@@ -1,14 +1,21 @@
-const http = require('http')
-const WebSocket = require('faye-websocket')
+'use strict'
 
-const server = http.createServer()
+const gateway = require('./../index')
+const PORT = process.env.PORT || 8080
 
-server.on('upgrade', (request, socket, body) => {
-  const client = new WebSocket(request, socket, body)
-  const target = new WebSocket.Client('ws://ws.ifelse.io')
+gateway({
+  routes: [{
+    // ... other HTTP or WebSocket routes
+  }, {
+    proxyType: 'websocket',
+    prefix: '/echo',
+    target: 'ws://ws.ifelse.io',
+    hooks: {
+      onOpen: (ws, searchParams) => {
 
-  client.pipe(target)
-  target.pipe(client)
+      }
+    }
+  }]
+}).start(PORT).then(server => {
+  console.log(`API Gateway listening on ${PORT} port!`)
 })
-
-server.listen(3000)

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ declare namespace fastgateway {
   }
 
   interface WebSocketHooks {
-    onOpen?: Function;
+    onOpen?: (ws: any, searchParams: URLSearchParams) => Promise<void>;
   }
 
   interface Hooks {

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,6 @@ declare namespace fastgateway {
     proxyType?: Type;
     proxyConfig?: {};
     proxyHandler?: Function;
-    http2?: boolean;
     pathRegex?: string;
     timeout?: number;
     prefix: string;
@@ -31,6 +30,16 @@ declare namespace fastgateway {
     methods?: Method[];
     middlewares?: Function[];
     hooks?: Hooks;
+  }
+
+  interface WebSocketRoute {
+    proxyType: 'websocket';
+    proxyConfig?: {};
+    proxyHandler?: Function;
+    prefix: string;
+    prefixRewrite?: string;
+    target: string;
+    middlewares?: Function[];
   }
 
   interface Hooks {
@@ -54,7 +63,7 @@ declare namespace fastgateway {
     pathRegex?: string;
     timeout?: number;
     targetOverride?: string;
-    routes: Route[];
+    routes: Route[] | WebSocketRoute[];
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,12 +35,15 @@ declare namespace fastgateway {
 
   interface WebSocketRoute {
     proxyType: 'websocket';
-    proxyConfig?: {};
-    proxyHandler?: Function;
+    proxyConfig?: {}; // https://github.com/faye/faye-websocket-node#initialization-options
     prefix: string;
-    prefixRewrite?: string;
     target: string;
-    middlewares?: Function[];
+    subProtocols?: []; // https://github.com/faye/faye-websocket-node#subprotocol-negotiation
+    hooks?: WebSocketHooks;
+  }
+
+  interface WebSocketHooks {
+    onOpen?: Function;
   }
 
   interface Hooks {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const defaultProxyHandler = (req, res, url, proxy, proxyOpts) => proxy(req, res,
 const DEFAULT_METHODS = require('restana/libs/methods').filter(method => method !== 'all')
 const send = require('@polka/send-type')
 const PROXY_TYPES = ['http', 'lambda']
-const wsProxy = require('./lib/ws-proxy')
+const registerWebSocketRoutes = require('./lib/ws-proxy')
 
 const gateway = (opts) => {
   const proxyFactory = opts.proxyFactory || defaultProxyFactory
@@ -35,9 +35,8 @@ const gateway = (opts) => {
   })
 
   // processing websocket routes
-  const wsRoutes = opts.routes.filter(route => route.proxyType === 'websocket')
-  wsProxy({
-    routes: wsRoutes,
+  registerWebSocketRoutes({
+    routes: opts.routes.filter(route => route.proxyType === 'websocket'),
     server: router.getServer()
   })
 

--- a/lib/default-hooks.js
+++ b/lib/default-hooks.js
@@ -5,6 +5,9 @@ const toArray = require('stream-to-array')
 const TRANSFER_ENCODING_HEADER_NAME = 'transfer-encoding'
 
 module.exports = {
+  websocket: {
+    onOpenNoOp (ws, searchParams) { }
+  },
   lambda: {
     onRequestNoOp (req, res) { },
     onResponse (req, res, response) {

--- a/lib/ws-proxy.js
+++ b/lib/ws-proxy.js
@@ -19,10 +19,11 @@ module.exports = (config) => {
 
       if (route) {
         const subProtocols = route.subProtocols || []
-        const client = new WebSocket(req, socket, body, subProtocols)
         route.hooks = route.hooks || {}
         const onOpen = route.hooks.onOpen || onOpenNoOp
 
+        const client = new WebSocket(req, socket, body, subProtocols)
+        
         try {
           await onOpen(client, url.searchParams)
 

--- a/lib/ws-proxy.js
+++ b/lib/ws-proxy.js
@@ -1,23 +1,23 @@
 'use strict'
 
 const WebSocket = require('faye-websocket')
-
-function onOpenNoOp () {}
+const { onOpenNoOp } = require('./default-hooks').websocket
 
 module.exports = (config) => {
   const { routes, server } = config
 
-  const prefix2route = {}
+  const prefix2route = new Map()
   for (const route of routes) {
-    prefix2route[route.prefix] = route
+    prefix2route.set(route.prefix, route)
   }
 
   server.on('upgrade', async (req, socket, body) => {
     if (WebSocket.isWebSocket(req)) {
       const url = new URL('http://fw' + req.url)
-      const route = prefix2route[url.pathname]
+      const prefix = url.pathname || '/'
 
-      if (route) {
+      if (prefix2route.has(prefix)) {
+        const route = prefix2route.get(prefix)
         const subProtocols = route.subProtocols || []
         route.hooks = route.hooks || {}
         const onOpen = route.hooks.onOpen || onOpenNoOp

--- a/lib/ws-proxy.js
+++ b/lib/ws-proxy.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
 
   server.on('upgrade', async (req, socket, body) => {
     if (WebSocket.isWebSocket(req)) {
-      const url = new URL('http://dummy' + req.url)
+      const url = new URL('http://fw' + req.url)
       const route = prefix2route[url.pathname]
 
       if (route) {
@@ -32,13 +32,11 @@ module.exports = (config) => {
           client.pipe(remote)
           remote.pipe(client)
         } catch (err) {
-          client.close(err.closeEventCode || 4000, err.message)
+          client.close(err.closeEventCode || 4500, err.message)
         }
       } else {
-        socket.destroy()
+        socket.end()
       }
-    } else {
-      socket.destroy()
-    }
+    } 
   })
 }

--- a/lib/ws-proxy.js
+++ b/lib/ws-proxy.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const WebSocket = require('faye-websocket')
+
+function onOpenNoOp () {}
+
+module.exports = (config) => {
+  const { routes, server } = config
+
+  const prefix2route = {}
+  for (const route of routes) {
+    prefix2route[route.prefix] = route
+  }
+
+  server.on('upgrade', async (req, socket, body) => {
+    if (WebSocket.isWebSocket(req)) {
+      const url = new URL('http://dummy' + req.url)
+      const route = prefix2route[url.pathname]
+
+      if (route) {
+        const subProtocols = route.subProtocols || []
+        const client = new WebSocket(req, socket, body, subProtocols)
+        route.hooks = route.hooks || {}
+        const onOpen = route.hooks.onOpen || onOpenNoOp
+
+        try {
+          await onOpen(client, url.searchParams)
+
+          const target = route.target + '?' + url.searchParams.toString()
+          const remote = new WebSocket.Client(target, subProtocols, route.proxyConfig)
+
+          client.pipe(remote)
+          remote.pipe(client)
+        } catch (err) {
+          client.close(err.closeEventCode || 4000, err.message)
+        }
+      } else {
+        socket.destroy()
+      }
+    } else {
+      socket.destroy()
+    }
+  })
+}

--- a/lib/ws-proxy.js
+++ b/lib/ws-proxy.js
@@ -23,7 +23,7 @@ module.exports = (config) => {
         const onOpen = route.hooks.onOpen || onOpenNoOp
 
         const client = new WebSocket(req, socket, body, subProtocols)
-        
+
         try {
           await onOpen(client, url.searchParams)
 
@@ -38,6 +38,6 @@ module.exports = (config) => {
       } else {
         socket.end()
       }
-    } 
+    }
   })
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "nyc mocha test/*.test.js",
     "format": "npx standard --fix",
-    "lint": "npx standard"
+    "lint": "npx standard",
+    "ws-bench": "npx artillery run benchmark/websocket/artillery-perf1.yml"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "devDependencies": {
     "@types/express": "^4.17.11",
+    "artillery": "^2.0.0-6",
     "aws-sdk": "^2.1037.0",
     "chai": "^4.3.4",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "express": "^4.17.1",
     "express-jwt": "^6.1.0",
     "express-rate-limit": "^5.5.1",
+    "faye-websocket": "^0.11.4",
     "fg-multiple-hooks": "^1.3.0",
     "helmet": "^4.6.0",
     "http-lambda-proxy": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/jkyberneees/fast-gateway#readme",
   "dependencies": {
     "@polka/send-type": "^0.5.2",
-    "fast-proxy-lite": "^1.0.1",
+    "fast-proxy-lite": "^1.0.2",
     "http-cache-middleware": "^1.3.8",
     "restana": "^4.9.2",
     "stream-to-array": "^2.3.0"
@@ -42,7 +42,7 @@
   ],
   "devDependencies": {
     "@types/express": "^4.17.11",
-    "aws-sdk": "^2.1023.0",
+    "aws-sdk": "^2.1037.0",
     "chai": "^4.3.4",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/test/ws-proxy.test.js
+++ b/test/ws-proxy.test.js
@@ -1,0 +1,138 @@
+'use strict'
+
+const gateway = require('../index')
+const WebSocket = require('faye-websocket')
+const http = require('http')
+
+/* global describe, it */
+const expect = require('chai').expect
+
+describe('ws-proxy', () => {
+  let gw, echoServer
+
+  it('initialize', async () => {
+    echoServer = http.createServer()
+    echoServer.on('upgrade', (request, socket, body) => {
+      if (WebSocket.isWebSocket(request)) {
+        const ws = new WebSocket(request, socket, body)
+
+        ws.on('message', (event) => {
+          ws.send(JSON.stringify({
+            data: event.data,
+            url: request.url
+          }))
+        })
+      }
+    })
+    echoServer.listen(3000)
+
+    gw = gateway({
+      routes: [{
+        proxyType: 'websocket',
+        prefix: '/',
+        target: 'ws://127.0.0.1:3000'
+      }, {
+        proxyType: 'websocket',
+        prefix: '/echo',
+        target: 'ws://127.0.0.1:3000'
+      }, {
+        proxyType: 'websocket',
+        prefix: '/echo-auth',
+        target: 'ws://127.0.0.1:3000',
+        hooks: {
+          onOpen (ws, searchParams) {
+            if (searchParams.get('accessToken') !== '12345') {
+              const err = new Error('Unauthorized')
+              err.closeEventCode = 4401
+
+              throw err
+            }
+          }
+        }
+      }, {
+        proxyType: 'websocket',
+        prefix: '/echo-params',
+        target: 'ws://127.0.0.1:3000',
+        hooks: {
+          onOpen (ws, searchParams) {
+            searchParams.set('x-token', 'abc')
+          }
+        }
+      }]
+    })
+
+    await gw.start(8080)
+  })
+
+  it('should echo using default prefix', (done) => {
+    const ws = new WebSocket.Client('ws://127.0.0.1:8080')
+    const msg = 'hello'
+
+    ws.on('message', (event) => {
+      const { data } = JSON.parse(event.data)
+      expect(data).equals('hello')
+
+      ws.close()
+      done()
+    })
+
+    ws.send(msg)
+  })
+
+  it('should echo', (done) => {
+    const ws = new WebSocket.Client('ws://127.0.0.1:8080/echo')
+    const msg = 'hello'
+
+    ws.on('message', (event) => {
+      const { data } = JSON.parse(event.data)
+      expect(data).equals('hello')
+
+      ws.close()
+      done()
+    })
+
+    ws.send(msg)
+  })
+
+  it('should fail auth', (done) => {
+    const ws = new WebSocket.Client('ws://127.0.0.1:8080/echo-auth?accessToken=2')
+    ws.on('close', (event) => {
+      done()
+    })
+  })
+
+  it('should pass auth', (done) => {
+    const ws = new WebSocket.Client('ws://127.0.0.1:8080/echo-auth?accessToken=12345')
+    const msg = 'hello'
+
+    ws.on('message', (event) => {
+      const { data } = JSON.parse(event.data)
+      expect(data).equals('hello')
+
+      ws.close()
+      done()
+    })
+
+    ws.send(msg)
+  })
+
+  it('should rewrite search params', (done) => {
+    const ws = new WebSocket.Client('ws://127.0.0.1:8080/echo-params')
+    const msg = 'hello'
+
+    ws.on('message', (event) => {
+      const { url } = JSON.parse(event.data)
+      expect(url).contains('?x-token=abc')
+
+      ws.close()
+      done()
+    })
+
+    ws.send(msg)
+  })
+
+  it('shutdown', async () => {
+    await gw.close()
+    echoServer.close()
+  })
+})


### PR DESCRIPTION
Usage example:
```js
'use strict'

const gateway = require('fast-gateway')
const WebSocket = require('faye-websocket')
const http = require('http')

gateway({
  routes: [{
    proxyType: 'websocket',
    prefix: '/echo',
    target: 'ws://127.0.0.1:3000'
  }]
}).start(8080)


const service = http.createServer()
service.on('upgrade', (request, socket, body) => {
  if (WebSocket.isWebSocket(request)) {
    const ws = new WebSocket(request, socket, body)
    
    ws.on('message', (event) => {
      ws.send(event.data)
    })
  }
})
service.listen(3000)

```

Artillery Benchmarks:
```yaml
config:
  target: "ws://localhost:8080/echo"
  phases:
    - duration: 15 
      arrivalRate: 20 
      rampTo: 500
      name: "Ramping up the load"
scenarios:
  - engine: "ws"
    flow:
      - send: 'echo me'
```
```bash
% npx artillery run benchmark/websocket/artillery-perf1.yml
Phase started: Ramping up the load (index: 0, duration: 15s) 19:43:33(+0100)

Phase completed: Ramping up the load (index: 0, duration: 15s) 19:43:49(+0100)

--------------------------------------
Metrics for period to: 19:43:40(+0100) (width: 6.14s)
--------------------------------------

vusers.created_by_name.0: ................................... 709
vusers.created.total: ....................................... 709
vusers.completed: ........................................... 709
vusers.session_length:
  min: ...................................................... 1.1
  max: ...................................................... 19.8
  median: ................................................... 2
  p95: ...................................................... 3.9
  p99: ...................................................... 10.7
websocket.send_rate: ........................................ 121/sec
websocket.messages_sent: .................................... 709


--------------------------------------
Metrics for period to: 19:43:50(+0100) (width: 9.598s)
--------------------------------------

vusers.created_by_name.0: ................................... 3369
vusers.created.total: ....................................... 3369
vusers.completed: ........................................... 3369
vusers.session_length:
  min: ...................................................... 1
  max: ...................................................... 56.2
  median: ................................................... 2
  p95: ...................................................... 5.3
  p99: ...................................................... 16.3
websocket.send_rate: ........................................ 358/sec
websocket.messages_sent: .................................... 3369


All VUs finished. Total time: 17 seconds

--------------------------------
Summary report @ 19:43:50(+0100)
--------------------------------

vusers.created_by_name.0: ................................... 4078
vusers.created.total: ....................................... 4078
vusers.completed: ........................................... 4078
vusers.session_length:
  min: ...................................................... 1
  max: ...................................................... 56.2
  median: ................................................... 2
  p95: ...................................................... 5
  p99: ...................................................... 15.3
websocket.send_rate: ........................................ 241/sec
websocket.messages_sent: .................................... 4078
```