### PR TITLE
using micromatch to compare ws prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ WebSockets proxying is supported since `v3.1.0`. Main considerations:
     proxyType: 'websocket';
     // https://github.com/faye/faye-websocket-node#initialization-options
     proxyConfig?: {}; 
-    prefix: string;
+    // used as micromatch matcher pattern: https://www.npmjs.com/package/micromatch
+    // prefix examples: '/graphql', '/ws-all/*', ['/rtp', '/rtp/*.flv'], '!/media/*.avi'
+    prefix: string; 
     target: string;
     // https://github.com/faye/faye-websocket-node#subprotocol-negotiation
     subProtocols?: []; 

--- a/lib/ws-proxy.js
+++ b/lib/ws-proxy.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const micromatch = require('micromatch')
 const { onOpenNoOp } = require('./default-hooks').websocket
 
 module.exports = (config) => {
@@ -7,18 +8,17 @@ module.exports = (config) => {
 
   const { routes, server } = config
 
-  const prefix2route = new Map()
-  for (const route of routes) {
-    prefix2route.set(route.prefix, route)
-  }
+  routes.forEach(route => {
+    route._isMatch = micromatch.matcher(route.prefix)
+  })
 
   server.on('upgrade', async (req, socket, body) => {
     if (WebSocket.isWebSocket(req)) {
       const url = new URL('http://fw' + req.url)
       const prefix = url.pathname || '/'
 
-      if (prefix2route.has(prefix)) {
-        const route = prefix2route.get(prefix)
+      const route = routes.find(route => route._isMatch(prefix))
+      if (route) {
         const subProtocols = route.subProtocols || []
         route.hooks = route.hooks || {}
         const onOpen = route.hooks.onOpen || onOpenNoOp

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "fast-proxy-lite": "^1.1.0",
     "http-cache-middleware": "^1.3.8",
     "restana": "^4.9.3",
-    "stream-to-array": "^2.3.0"
+    "stream-to-array": "^2.3.0",
+    "micromatch": "^4.0.5"
   },
   "files": [
     "lib/",
@@ -44,7 +45,7 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "artillery": "^2.0.0-14",
-    "aws-sdk": "^2.1106.0",
+    "aws-sdk": "^2.1111.0",
     "chai": "^4.3.6",
     "cors": "^2.8.5",
     "express": "^4.17.3",
@@ -55,7 +56,6 @@
     "helmet": "^5.0.2",
     "http-lambda-proxy": "^1.1.4",
     "load-balancers": "^1.3.52",
-    "micromatch": "^4.0.5",
     "mocha": "^9.2.2",
     "nyc": "^15.1.0",
     "opossum": "^6.3.0",

--- a/test/ws-proxy.test.js
+++ b/test/ws-proxy.test.js
@@ -37,7 +37,7 @@ describe('ws-proxy', () => {
         target: 'ws://127.0.0.1:3000'
       }, {
         proxyType: 'websocket',
-        prefix: '/echo-auth',
+        prefix: '/*-auth',
         target: 'ws://127.0.0.1:3000',
         hooks: {
           onOpen (ws, searchParams) {


### PR DESCRIPTION
Changes:
- Extending WebSocket routes prefix matching with micromatch: https://www.npmjs.com/package/micromatch

Closes: https://github.com/BackendStack21/fast-gateway/issues/73