### PR TITLE
fix(gateway): allow custom proxyFactory to use non-default proxyTypes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,8 +131,12 @@ module.exports.handler = serverless(service)
   timeout: 0,
   // Optional "target" value that overrides the routes "target" config value. Feature intended for testing purposes.
   targetOverride: "https://yourdev.api-gateway.com",
-  // Optional "Proxy Factory" implementation, allows the integration of custom proxying strategies.
-  // Default value: require('fast-proxy-lite/lib/proxy-factory')
+  // Optional "Proxy Factory" implementation, allows integration of custom proxying strategies.
+  // Behavior:
+  // - If it returns any value (e.g. a custom proxy), that value will be used directly.
+  // - If it returns `undefined` (or does not return anything), the default factory from `fast-gateway` will be used as a fallback.
+  // - If it returns `null`, no proxy will be used and the default factory will be skipped entirely.
+  // Default: the built-in proxy factory from `fast-gateway`
   proxyFactory: ({ proxyType, opts, route }) => {...}
 
   // HTTP proxy

--- a/index.js
+++ b/index.js
@@ -9,13 +9,13 @@ const defaultProxyHandler = (req, res, url, proxy, proxyOpts) =>
 const DEFAULT_METHODS = require('restana/libs/methods').filter(
   (method) => method !== 'all'
 )
-const NOOP = (req, res) => {};
+const NOOP = (req, res) => {}
 const send = require('@polka/send-type')
 const PROXY_TYPES = ['http', 'lambda']
 const registerWebSocketRoutes = require('./lib/ws-proxy')
 
 const gateway = (opts) => {
-  const proxyFactory = opts.proxyFactory ? (...args) => ((r) => r === undefined ? defaultProxyFactory(...args) : r)(opts.proxyFactory(...args)) : defaultProxyFactory;
+  const proxyFactory = opts.proxyFactory ? (...args) => ((r) => r === undefined ? defaultProxyFactory(...args) : r)(opts.proxyFactory(...args)) : defaultProxyFactory
 
   opts = Object.assign(
     {
@@ -68,7 +68,7 @@ const gateway = (opts) => {
 
       // retrieve proxy type
       const { proxyType = 'http' } = route
-      const isDefaultProxyType = PROXY_TYPES.includes(proxyType);
+      const isDefaultProxyType = PROXY_TYPES.includes(proxyType)
       if (!opts.proxyFactory && !isDefaultProxyType) {
         throw new Error(
           'Unsupported proxy type, expecting one of ' + PROXY_TYPES.toString()
@@ -76,8 +76,8 @@ const gateway = (opts) => {
       }
 
       // retrieve default hooks for proxy
-      const hooksForDefaultType = isDefaultProxyType ? require('./lib/default-hooks')[proxyType] : {};
-      const { onRequestNoOp = NOOP, onResponse = NOOP } = hooksForDefaultType;
+      const hooksForDefaultType = isDefaultProxyType ? require('./lib/default-hooks')[proxyType] : {}
+      const { onRequestNoOp = NOOP, onResponse = NOOP } = hooksForDefaultType
 
       // populating required NOOPS
       route.hooks = route.hooks || {}

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const PROXY_TYPES = ['http', 'lambda']
 const registerWebSocketRoutes = require('./lib/ws-proxy')
 
 const gateway = (opts) => {
-  const proxyFactory = (...args) => opts.proxyFactory?.(...args) ?? defaultProxyFactory(...args);
+  const proxyFactory = opts.proxyFactory ? (...args) => ((r) => r === undefined ? defaultProxyFactory(...args) : r)(opts.proxyFactory(...args)) : defaultProxyFactory;
 
   opts = Object.assign(
     {

--- a/index.js
+++ b/index.js
@@ -9,12 +9,13 @@ const defaultProxyHandler = (req, res, url, proxy, proxyOpts) =>
 const DEFAULT_METHODS = require('restana/libs/methods').filter(
   (method) => method !== 'all'
 )
+const NOOP = (req, res) => {};
 const send = require('@polka/send-type')
 const PROXY_TYPES = ['http', 'lambda']
 const registerWebSocketRoutes = require('./lib/ws-proxy')
 
 const gateway = (opts) => {
-  const proxyFactory = opts.proxyFactory || defaultProxyFactory
+  const proxyFactory = (...args) => opts.proxyFactory?.(...args) ?? defaultProxyFactory(...args);
 
   opts = Object.assign(
     {
@@ -67,16 +68,16 @@ const gateway = (opts) => {
 
       // retrieve proxy type
       const { proxyType = 'http' } = route
-      if (!PROXY_TYPES.includes(proxyType)) {
+      const isDefaultProxyType = PROXY_TYPES.includes(proxyType);
+      if (!opts.proxyFactory && !isDefaultProxyType) {
         throw new Error(
           'Unsupported proxy type, expecting one of ' + PROXY_TYPES.toString()
         )
       }
 
       // retrieve default hooks for proxy
-      const { onRequestNoOp, onResponse } = require('./lib/default-hooks')[
-        proxyType
-      ]
+      const hooksForDefaultType = isDefaultProxyType ? require('./lib/default-hooks')[proxyType] : {};
+      const { onRequestNoOp = NOOP, onResponse = NOOP } = hooksForDefaultType;
 
       // populating required NOOPS
       route.hooks = route.hooks || {}


### PR DESCRIPTION
This PR improves flexibility in the gateway by allowing custom proxyFactory implementations to define and use custom proxyType values without triggering an "Unsupported proxy type" error.

**Changes**
- Wrapped opts.proxyFactory with a fallback to defaultProxyFactory only if it returns undefined
- Skip proxyType validation when a custom proxyFactory is provided
- Default missing proxy hooks to NOOP functions

Previously, providing a custom proxyFactory and proxyType would still result in an error unless the type was listed in the internal PROXY_TYPES list. This fix ensures full control when extending proxy behavior through configuration.

```
// ——————————————————————————
// 1) “Normal” mode: return undefined to fall back
// ——————————————————————————
gateway({
  proxyFactory: (ctx) => {
    const { proxyType, opts, route } = ctx;

    if (proxyType === 'custom') {
      return myCustomProxy;
    }

    // returning undefined ⇒ defaultProxyFactory will be used
  }
});

// ——————————————————————————
// 2) “Disable fallback” mode: return null to opt out
// ——————————————————————————
gateway({
  proxyFactory: (ctx) => {
    const { proxyType, opts, route } = ctx;

    if (proxyType === 'custom') {
      return myCustomProxy;
    }

    // returning null ⇒ no fallback
    return null;
  }
});
```