### PR TITLE
fix(types): allow proxyFactory to return null or undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import * as restana from 'restana'
 
 declare namespace fastgateway {
-  type Type = 'http' | 'lambda'
+  type Type = 'http' | 'lambda' | (string & {})
 
   type Method =
     | 'GET'
@@ -20,7 +20,7 @@ declare namespace fastgateway {
   }
 
   interface ProxyFactoryOpts {
-    proxyType: string
+    proxyType: Type
     opts: {}
     route: Route
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ declare namespace fastgateway {
 
   interface Options<P extends restana.Protocol> {
     server?: Object | restana.Service<P> | Express.Application
-    proxyFactory?: (opts: ProxyFactoryOpts) => Function|null|undefined
+    proxyFactory?: (opts: ProxyFactoryOpts) => Function | null | undefined
     restana?: {}
     middlewares?: Function[]
     pathRegex?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ declare namespace fastgateway {
 
   interface Options<P extends restana.Protocol> {
     server?: Object | restana.Service<P> | Express.Application
-    proxyFactory?: (opts: ProxyFactoryOpts) => Function
+    proxyFactory?: (opts: ProxyFactoryOpts) => Function|null|undefined
     restana?: {}
     middlewares?: Function[]
     pathRegex?: string


### PR DESCRIPTION
Follow-up to [#96 allow custom proxyFactory to use non-default proxyTypes](https://github.com/BackendStack21/fast-gateway/pull/96)
This updates the proxyFactory type to allow returning null or undefined.

Apologies for missing this in the previous PR!

**Preview of the error:**
![image](https://github.com/user-attachments/assets/0069c020-2300-439c-8855-8de94875b1cc)
