### PR TITLE
Add servicesJsonRoute option and remove unneeded dependency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,9 @@ module.exports.handler = serverless(service)
   // - If it returns `null`, no proxy will be used and the default factory will be skipped entirely.
   // Default: the built-in proxy factory from `fast-gateway`
   proxyFactory: ({ proxyType, opts, route }) => {...}
+   // Optional toggle for exposing minimal documentation of registered services at `GET /services.json`
+   // Default value: true
+  servicesJsonRoute: true
 
   // HTTP proxy
   routes: [{
@@ -213,6 +216,8 @@ For developers reference, default hooks implementation are located in `lib/defau
 # The "_GET /services.json_" endpoint
 
 Since version `1.3.5` the gateway exposes minimal documentation about registered services at: `GET /services.json`
+
+Since version `4.2.0`, the `/services.json` route can be disabled by setting `servicesJsonRoute: false` in the gateway options.
 
 Example output:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,7 +140,7 @@ module.exports.handler = serverless(service)
   proxyFactory: ({ proxyType, opts, route }) => {...}
    // Optional toggle for exposing minimal documentation of registered services at `GET /services.json`
    // Default value: true
-  servicesJsonRoute: true
+  enableServicesEndpoint: true
 
   // HTTP proxy
   routes: [{
@@ -217,7 +217,7 @@ For developers reference, default hooks implementation are located in `lib/defau
 
 Since version `1.3.5` the gateway exposes minimal documentation about registered services at: `GET /services.json`
 
-Since version `4.2.0`, the `/services.json` route can be disabled by setting `servicesJsonRoute: false` in the gateway options.
+Since version `4.2.0`, the `/services.json` route can be disabled by setting `enableServicesEndpoint: false` in the gateway options.
 
 Example output:
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,7 @@ declare namespace fastgateway {
     pathRegex?: string
     timeout?: number
     targetOverride?: string
+    servicesJsonRoute?: boolean
     routes: (Route | WebSocketRoute)[]
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare namespace fastgateway {
     pathRegex?: string
     timeout?: number
     targetOverride?: string
-    servicesJsonRoute?: boolean
+    enableServicesEndpoint?: boolean
     routes: (Route | WebSocketRoute)[]
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const DEFAULT_METHODS = require('restana/libs/methods').filter(
   (method) => method !== 'all'
 )
 const NOOP = (req, res) => {}
-const send = require('@polka/send-type')
 const PROXY_TYPES = ['http', 'lambda']
 const registerWebSocketRoutes = require('./lib/ws-proxy')
 
@@ -47,7 +46,9 @@ const gateway = (opts) => {
     docs: route.docs
   }))
   router.get('/services.json', (req, res) => {
-    send(res, 200, services)
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(services))
   })
 
   // processing websocket routes

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const gateway = (opts) => {
     {
       middlewares: [],
       pathRegex: '/*',
-      servicesJsonRoute: true
+      enableServicesEndpoint: true
     },
     opts
   )
@@ -46,7 +46,7 @@ const gateway = (opts) => {
     prefix: route.prefix,
     docs: route.docs
   }))
-  if (opts.servicesJsonRoute) {
+  if (opts.enableServicesEndpoint) {
     router.get('/services.json', (req, res) => {
       res.statusCode = 200
       res.setHeader('Content-Type', 'application/json')

--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ const gateway = (opts) => {
   opts = Object.assign(
     {
       middlewares: [],
-      pathRegex: '/*'
+      pathRegex: '/*',
+      servicesJsonRoute: true
     },
     opts
   )
@@ -45,11 +46,13 @@ const gateway = (opts) => {
     prefix: route.prefix,
     docs: route.docs
   }))
-  router.get('/services.json', (req, res) => {
-    res.statusCode = 200
-    res.setHeader('Content-Type', 'application/json')
-    res.end(JSON.stringify(services))
-  })
+  if (opts.servicesJsonRoute) {
+    router.get('/services.json', (req, res) => {
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify(services))
+    })
+  }
 
   // processing websocket routes
   const wsRoutes = opts.routes.filter(

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@polka/send-type": "^0.5.2",
     "@types/node": "^22.13.11",
     "@types/express": "^5.0.0",
     "artillery": "^2.0.21",


### PR DESCRIPTION
- Feature: Introduced the servicesJsonRoute option to control the exposure of service documentation.
- Chore: Removed unneeded @polka/send-type dependency

**💻 Code example:**
```
const server = gateway({
  servicesJsonRoute: false, // optional, default value: true
  routes: [
    {
      prefix: '/service',
      target: 'http://127.0.0.1:3000',
    },
  ],
})
```

**ℹ️ Note:** 
I used version number 4.2.0 in the documentation, assuming that will be the next release version. Please let me know if a different version is used.