### PR TITLE
fix: update restana methods API compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const defaultProxyFactory = require('./lib/proxy-factory')
 const restana = require('restana')
 const defaultProxyHandler = (req, res, url, proxy, proxyOpts) =>
   proxy(req, res, url, proxyOpts)
-const DEFAULT_METHODS = require('restana/libs/methods').filter(
+const DEFAULT_METHODS = require('restana/libs/methods').BASE.filter(
   (method) => method !== 'all'
 )
 const NOOP = (req, res) => {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fast-gateway",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "A Node.js API Gateway for the masses!",
   "main": "index.js",
   "types": "index.d.ts",
@@ -31,7 +31,7 @@
     "fast-proxy-lite": "^1.1.2",
     "http-cache-middleware": "^1.4.1",
     "micromatch": "^4.0.8",
-    "restana": "^5.0.0",
+    "restana": "^6.0.0",
     "stream-to-array": "^2.3.0"
   },
   "files": [
@@ -42,26 +42,26 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@types/node": "^22.13.11",
-    "@types/express": "^5.0.0",
-    "artillery": "^2.0.21",
-    "aws-sdk": "^2.1691.0",
-    "chai": "^4.5.0",
+    "@types/node": "^25.7.0",
+    "@types/express": "^5.0.6",
+    "artillery": "^2.0.31",
+    "aws-sdk": "^2.1693.0",
+    "chai": "^6.2.2",
     "consistent-hash": "^1.2.2",
-    "cors": "^2.8.5",
-    "express": "^5.0.1",
-    "express-jwt": "^7.7.8",
-    "express-rate-limit": "^6.11.2",
+    "cors": "^2.8.6",
+    "express": "^5.2.1",
+    "express-jwt": "^8.5.1",
+    "express-rate-limit": "^8.5.1",
     "faye-websocket": "^0.11.4",
     "fg-multiple-hooks": "^1.3.0",
-    "helmet": "^7.2.0",
+    "helmet": "^8.1.0",
     "http-lambda-proxy": "^1.1.4",
     "load-balancers": "^1.3.52",
-    "mocha": "^10.8.2",
-    "nyc": "^17.1.0",
+    "mocha": "^11.7.5",
+    "nyc": "^18.0.0",
     "pem": "^1.14.8",
     "request-ip": "^3.3.0",
-    "response-time": "^2.3.3",
-    "supertest": "^7.0.0"
+    "response-time": "^2.3.4",
+    "supertest": "^7.2.2"
   }
 }


### PR DESCRIPTION
The newer version of restana changed its export structure. The require('restana/libs/methods') now returns a function with a .BASE property containing the HTTP methods array, rather than directly exporting the array.

Fixes test failures with: TypeError: require(...).filter is not a function