### PR TITLE
fix: MAX_BUFFER_SIZE guard for chunked responses + bump fast-proxy-lite 1.1.3

### DIFF
--- a/lib/default-hooks.js
+++ b/lib/default-hooks.js
@@ -1,8 +1,11 @@
 'use strict'
 
 const pump = require('pump')
-const toArray = require('stream-to-array')
 const TRANSFER_ENCODING_HEADER_NAME = 'transfer-encoding'
+
+// Maximum size in bytes for buffered chunked responses (Connection: close)
+// Prevents memory exhaustion from unbounded upstream response bodies
+const MAX_BUFFER_SIZE = 1 * 1024 * 1024 // 1MB
 
 module.exports = {
   websocket: {
@@ -38,8 +41,22 @@ module.exports = {
           }
 
           if (!stream.headers['content-length']) {
-            // pack all pieces into 1 buffer to calculate content length
-            const resBuffer = Buffer.concat(await toArray(stream))
+            // Collect chunks with size limit to prevent OOM
+            const chunks = []
+            let totalSize = 0
+
+            for await (const chunk of stream) {
+              totalSize += chunk.length
+              if (totalSize > MAX_BUFFER_SIZE) {
+                stream.destroy()
+                res.statusCode = 502
+                res.end('Response body exceeds maximum allowed size')
+                return
+              }
+              chunks.push(chunk)
+            }
+
+            const resBuffer = Buffer.concat(chunks)
 
             // add content-length header and send the merged response buffer
             res.setHeader('content-length', '' + Buffer.byteLength(resBuffer))

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/jkyberneees/fast-gateway#readme",
   "dependencies": {
-    "fast-proxy-lite": "^1.1.2",
+    "fast-proxy-lite": "^1.1.3",
     "http-cache-middleware": "^1.4.1",
     "micromatch": "^4.0.8",
     "restana": "^6.0.0",
@@ -42,8 +42,8 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@types/node": "^25.7.0",
     "@types/express": "^5.0.6",
+    "@types/node": "^25.7.0",
     "artillery": "^2.0.31",
     "aws-sdk": "^2.1693.0",
     "chai": "^6.2.2",

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -31,6 +31,13 @@ describe('API Gateway', () => {
       res.write('1')
       res.end()
     })
+    remote.get('/large-chunked', (req, res) => {
+      // Sends a 2MB chunked response to test buffer overflow protection
+      const buf = Buffer.alloc(2 * 1024 * 1024, 'x')
+      res.writeHead(200, { 'content-type': 'application/octet-stream' })
+      res.write(buf)
+      res.end()
+    })
     remote.get('/cache', (req, res) => {
       res.setHeader('x-cache-timeout', '1 second')
       res.send({
@@ -367,6 +374,20 @@ describe('API Gateway', () => {
       .then((res) => {
         expect(res.text).to.equal('user1')
       })
+  })
+
+  it('large chunked rejected with 502 when Connection close (buffer limit)', async () => {
+    await request(gateway)
+      .get('/users/large-chunked')
+      .set({ Connection: 'close' })
+      .expect(502)
+  })
+
+  it('large chunked streamed normally when Connection keep-alive', async () => {
+    await request(gateway)
+      .get('/users/large-chunked')
+      .set('Connection', 'keep-alive')
+      .expect(200)
   })
 
   it('(Should overwrite query string using req.query) GET /qs - 200', async () => {


### PR DESCRIPTION
## Summary

Two security hardening changes:

### 1. Buffer overflow protection for chunked responses (🔴 Moderate)

**default-hooks.js** — The `onResponse` handler buffered unbounded chunked responses into memory when `Connection: close` was set. A malicious or misconfigured upstream could exhaust the gateway process memory.

**Fix:** Added a 1MB `MAX_BUFFER_SIZE` guard that tracks accumulated buffer size during chunk collection. When exceeded, the stream is destroyed and a **502 Bad Gateway** is returned instead of OOM-ing the process.

- Removed unused `stream-to-array` import (replaced with `for await` iterator)
- Added regression tests: 2MB chunked response → 502 rejection; keep-alive → streams normally

### 2. Bump fast-proxy-lite ^1.1.2 → ^1.1.3

Pulls in the SSRF fix: `buildURL()` now validates origin, blocking absolute-form HTTP requests that bypass the configured base URL.

## Test Plan

```
57 passing (19s) — full test suite green
```

### New tests
- `large chunked rejected with 502 when Connection close (buffer limit)` — 2MB chunked response with `Connection: close` → **502**
- `large chunked streamed normally when Connection keep-alive` — 2MB chunked with keep-alive → **200** (no buffering)

### Existing tests preserved
- All chunked transfer-encoding tests (close + keep-alive)
- All onError hook tests (sync, async, throws, no-error)
- All proxy, WS, cache, QS, lambda tests

## Files Changed

| File | Change |
|------|--------|
| `lib/default-hooks.js` | +23/-3 — MAX_BUFFER_SIZE guard, remove toArray |
| `package.json` | ^1.1.2 → ^1.1.3 fast-proxy-lite |
| `test/smoke.test.js` | +21 — regression tests for buffer overflow |